### PR TITLE
Make client tabs scrollable on mobile

### DIFF
--- a/src/app/clientes/page.tsx
+++ b/src/app/clientes/page.tsx
@@ -1185,8 +1185,8 @@ export default function ClientesPage() {
       ) : selectedClient && clientData ? (
         <div className="space-y-3">
           {/* Tab Navigation */}
-          <div className="bg-white rounded-lg p-2 border border-[#E2E4E9]">
-            <div className="flex space-x-1">
+          <div className="bg-white rounded-lg p-2 border border-[#E2E4E9] overflow-x-auto">
+            <div className="flex space-x-1 w-max">
               {[
                 { id: 'overview', label: 'Resumen', icon: BarChart3 },
                 { id: 'entries', label: 'Entradas', icon: Calendar },
@@ -1197,7 +1197,7 @@ export default function ClientesPage() {
                 <button
                   key={tab.id}
                   onClick={() => setActiveTab(tab.id as any)}
-                  className={`flex items-center px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  className={`flex items-center px-3 py-2 rounded-lg text-sm font-medium transition-colors shrink-0 ${
                     activeTab === tab.id
                       ? 'bg-blue-600 text-white'
                       : 'text-gray-600 hover:bg-gray-100'


### PR DESCRIPTION
## Summary
- Allow horizontal scrolling on client detail tabs
- Prevent tab buttons from shrinking to keep full labels visible

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac895333fc8327bb843b80b597870a